### PR TITLE
Update CropperAsset.php regarding deprecated version of @sjaakp/cropper

### DIFF
--- a/CropperAsset.php
+++ b/CropperAsset.php
@@ -23,7 +23,7 @@ class CropperAsset extends AssetBundle {
         'only' => [ 'js/*', 'css/*' ]
     ];
 
-    public $baseUrl = '//unpkg.com/@sjaakp/cropper';
+    public $baseUrl = '//unpkg.com/@sjaakp/cropper@1.0.0';
     public $js = [ 'js/jquery.cropper.min.js' ];
     public $css = [ 'css/jquery.cropper.min.css' ];
 }


### PR DESCRIPTION
The yii2-illustrated-behavior extension stopped working because of needed old version 1.0.0 of @sjaakp/cropper.
